### PR TITLE
Fix compatibility with Octave 10 or newer

### DIFF
--- a/interfaces/octave/make_piqp.m
+++ b/interfaces/octave/make_piqp.m
@@ -53,12 +53,22 @@ end
 
 %% piqp_oct
 if any(strcmpi(what,'oct')) || any(strcmpi(what,'all'))
-   fprintf('Compiling PIQP Octave interface...\n');
+    fprintf('Compiling PIQP Octave interface...\n');
 
-    mkoctfile('-O3', '-DNDEBUG', '-march=native', '-std=gnu++14', ...
+    mkoctfile_args = {'-O3', '-DNDEBUG', '-march=native', ...
              ['-I', fullfile(piqp_dir, 'include')], ...
              ['-I', eigen_include_dir], ...
-             '-o', 'piqp_oct.oct', fullfile(piqp_dir, 'interfaces/octave/piqp_oct.cpp'));
+             '-o', 'piqp_oct.oct', ...
+             fullfile(piqp_dir, 'interfaces/octave/piqp_oct.cpp')};
+
+    if ~exist('verLessThan') || verLessThan("Octave", "10")
+        % Octave 10 or newer requires C++17 or newer.
+        % Attempting to lower that requirement to C++14 (with GNU extensions)
+        % leads to compilation errors.
+        mkoctfile_args = [{'-std=gnu++14'}, mkoctfile_args];
+    end
+
+    mkoctfile(mkoctfile_args{:});
 
     fprintf('[done]\n');
 


### PR DESCRIPTION
Octave 10 or newer requires C++17 or newer.
Attempting to lower that requirement to C++14 (with or without GNU extensions) leads to compilation errors.

A general remark: The current build rules for this package for Octave require that Octave can actually be executed. That might not be the case if this package is cross-built (e.g., on Linux for Windows).
If you'd like to support cross-building this package, build rules that are based on a `Makefile` might be better. (But the ability to cross-build is not a requirement for Octave packages.)