### PR TITLE
Enforce eigen ABI with Template Instantiation

### DIFF
--- a/include/piqp/typedefs.hpp
+++ b/include/piqp/typedefs.hpp
@@ -77,6 +77,21 @@ enum SolverMatrixType
     PIQP_SPARSE = 1
 };
 
+#ifdef PIQP_WITH_TEMPLATE_INSTANTIATION
+
+#define PIQP_CONCAT_IMPL(a, b) a##b
+#define PIQP_CONCAT(a, b) PIQP_CONCAT_IMPL(a, b)
+#define PIQP_EIGEN_ABI_CHECK_MAX_ALIGN PIQP_CONCAT(_piqp_eigen_abi_check_max_align_, EIGEN_MAX_ALIGN_BYTES)
+
+extern void PIQP_EIGEN_ABI_CHECK_MAX_ALIGN();
+inline void enforce_abi_compatibility() {
+    PIQP_EIGEN_ABI_CHECK_MAX_ALIGN();
+}
+
+static const auto _abi_enforcer = (enforce_abi_compatibility(), 0);
+
+#endif
+
 } // namespace piqp
 
 #endif //PIQP_TYPEDEFS_HPP

--- a/src/typedefs.cpp
+++ b/src/typedefs.cpp
@@ -1,0 +1,15 @@
+// This file is part of PIQP.
+//
+// Copyright (c) 2025 EPFL
+//
+// This source code is licensed under the BSD 2-Clause License found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "piqp/typedefs.hpp"
+
+namespace piqp
+{
+
+void PIQP_EIGEN_ABI_CHECK_MAX_ALIGN() {}
+
+} // namespace piqp


### PR DESCRIPTION
This PR introduces a mechanism that results in a link-time error if the Eigen ABI is incompatible with the pre-compiled library (template instantiation). This doesn't fix the ABI compatibilities, but instead, the user gets a link-time error and not a segmentation fault during runtime. This should circumvent issues like https://github.com/PREDICT-EPFL/piqp/issues/26 and https://github.com/PREDICT-EPFL/piqp/issues/31.

@traversaro, this approach might also be of interest to you.