### PR TITLE
Add support for Eigen 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-15-intel, macos-15, windows-latest ]
-        eigen: [ 3.3.7, 3.4.0 ]
+        eigen: [ 3.3.7, 3.4.0, 5.0.1 ]
         exclude:
           - os: macos-15
             eigen: 3.3.7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,11 @@ if (DEFINED EIGEN3_INCLUDE_DIRS AND NOT TARGET Eigen3::Eigen)
     add_library(Eigen3::Eigen INTERFACE IMPORTED)
     target_include_directories(Eigen3::Eigen INTERFACE ${EIGEN3_INCLUDE_DIRS})
 else ()
-    find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+    find_package(Eigen3 REQUIRED NO_MODULE)
+
+    if (Eigen3_VERSION VERSION_LESS "3.3")
+        message(FATAL_ERROR "Eigen3 >= 3.3 required, found ${Eigen3_VERSION}")
+    endif ()
 endif ()
 message(STATUS "Using Eigen3 from: ${EIGEN3_INCLUDE_DIRS}")
 

--- a/include/piqp/dense/ldlt_no_pivot.hpp
+++ b/include/piqp/dense/ldlt_no_pivot.hpp
@@ -239,10 +239,10 @@ public:
       * This method is provided for compatibility with other matrix decompositions, thus enabling generic code such as:
       * \code x = decomposition.adjoint().solve(b) \endcode
       */
-    const LDLTNoPivot& adjoint() const EIGEN_NOEXCEPT { return *this; }
+    const LDLTNoPivot& adjoint() const noexcept { return *this; }
 
-    inline Eigen::Index rows() const EIGEN_NOEXCEPT { return m_matrix.rows(); }
-    inline Eigen::Index cols() const EIGEN_NOEXCEPT { return m_matrix.cols(); }
+    inline Eigen::Index rows() const noexcept { return m_matrix.rows(); }
+    inline Eigen::Index cols() const noexcept { return m_matrix.cols(); }
 
 #ifndef EIGEN_PARSED_BY_DOXYGEN
     template<typename RhsType, typename DstType>

--- a/include/piqp/kkt_system.tpp
+++ b/include/piqp/kkt_system.tpp
@@ -8,6 +8,8 @@
 #ifndef PIQP_KKT_SYSTEM_TPP
 #define PIQP_KKT_SYSTEM_TPP
 
+#include <cassert>
+
 #include "piqp/kkt_system.hpp"
 #include "piqp/dense/kkt.hpp"
 #include "piqp/sparse/kkt.hpp"

--- a/include/piqp/utils/blasfeo_wrapper.hpp
+++ b/include/piqp/utils/blasfeo_wrapper.hpp
@@ -9,6 +9,7 @@
 #define PIQP_BLASFEO_WRAPPER
 
 #include <cstring>
+#include <cassert>
 
 #include "blasfeo.h"
 #include "piqp/utils/blasfeo_mat.hpp"

--- a/include/piqp/utils/eigen_matio.hpp
+++ b/include/piqp/utils/eigen_matio.hpp
@@ -13,6 +13,8 @@
 #ifndef PIQP_UTILS_EIGEN_MATIO_HPP
 #define PIQP_UTILS_EIGEN_MATIO_HPP
 
+#include <type_traits>
+
 #include "matio.h"
 #ifndef MATIO_VERSION
 #define MATIO_VERSION (MATIO_MAJOR_VERSION* 100 + MATIO_MINOR_VERSION* 10 + MATIO_RELEASE_LEVEL)
@@ -106,6 +108,11 @@ template <> struct type_matio<MAT_T_INT64>  { typedef int64_t  type; };
 template <> struct type_matio<MAT_T_UINT64> { typedef uint64_t type; };
 
 template <> struct class_matio<MAT_C_DOUBLE> { typedef double type; };
+
+template <typename T>
+auto to_signed_ptr(T* ptr) {
+    return reinterpret_cast<std::make_signed_t<T>*>(ptr);
+}
 
 } // Eigen::internal::
 
@@ -369,7 +376,8 @@ private:
             std::cout << "read_mat() wrong sparse format\n ";
             return -1;
         }
-        Map<SparseMatrix<data_t, ColMajor, typename std::remove_reference<decltype(*sparse->ir)>::type> > map(rows, cols, sparse->ndata, sparse->jc, sparse->ir, (data_t*) sparse->data);
+        using IndexType = std::make_signed_t<std::remove_reference_t<decltype(*sparse->ir)>>;
+        Map<SparseMatrix<data_t, ColMajor, IndexType> > map(rows, cols, sparse->ndata, internal::to_signed_ptr(sparse->jc), internal::to_signed_ptr(sparse->ir), (data_t*) sparse->data);
         matrix = map.template cast<Scalar>();
         return 0;
     }
@@ -390,7 +398,8 @@ private:
         Matrix<Scalar, Dynamic, 1> tmp(sparse->ndata);
         tmp.real() = map_re.template cast<Scalar>();
         tmp.imag() = map_im.template cast<Scalar>();
-        Map<SparseMatrix<Scalar, ColMajor, typename std::remove_reference<decltype(*sparse->ir)>::type> > map(rows, cols, sparse->ndata, sparse->jc, sparse->ir, tmp.data());
+        using IndexType = std::make_signed_t<std::remove_reference_t<decltype(*sparse->ir)>>;
+        Map<SparseMatrix<Scalar, ColMajor, IndexType> > map(rows, cols, sparse->ndata, internal::to_signed_ptr(sparse->jc), internal::to_signed_ptr(sparse->ir), tmp.data());
         matrix = map.template cast<Scalar>();
         return 0;
     }


### PR DESCRIPTION
`dense/ldlt_no_pivot.hpp` — replace removed `EIGEN_NOEXCEPT` for Eigen 5

`EIGEN_NOEXCEPT` was a pre-C++11 shim expanding to `noexcept`.
Eigen 5.0.x dropped it. Three call sites in `ldlt_no_pivot.hpp` fail:

```
dense/ldlt_no_pivot.hpp:242:39: error: expected ';' at end of declaration list
    const LDLTNoPivot& adjoint() const EIGEN_NOEXCEPT { return *this; }
                                       ^
```

## fix

`EIGEN_NOEXCEPT` → `noexcept` at lines 242, 244, 245.

all three are trivially noexcept:
- `adjoint()` — returns `const&` to `*this`
- `rows()` / `cols()` — forward to `Eigen::PlainObjectBase::rows()/cols()` which are `constexpr noexcept` in Eigen 5

## verified

clang++ C++20, Eigen 5.0.1, dense + sparse solver paths exercised.